### PR TITLE
Frontend: change "Clean output" button label to "Remove output"

### DIFF
--- a/src/whisper_api/frontend/static/index.html
+++ b/src/whisper_api/frontend/static/index.html
@@ -23,7 +23,7 @@
     <div id="result"></div>
   </div>
   <div style="display: flex; justify-content: center; gap: 20px; width: 100%;">
-    <button type="button" id="cleanOutputBtn" onclick="cleanOutput()" class="action-btn">Clean output</button>
+    <button type="button" id="cleanOutputBtn" onclick="cleanOutput()" class="action-btn">Remove output</button>
     <button type="button" id="downloadSrtBtn" onclick="downloadSrt()" class="action-btn">Download .srt file</button>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
Closes #29 

I was lazy and only changed the label, the underlying function and id are still using the "clean output" term.
Unsure how important it is for you to keep that consistent.